### PR TITLE
config: do not allow deletion of non-deletable configurations

### DIFF
--- a/provd/persist/common.py
+++ b/provd/persist/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2011-2014 Avencall
+# Copyright 2011-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """Persistent storage interface for 'documents'.
@@ -55,6 +55,13 @@ class InvalidIdError(Exception):
     pass
 
 
+class NonDeletableError(Exception):
+
+    def __init__(self, document):
+        super(NonDeletableError, self).__init__('The document {} is not deletable'.format(document))
+        self.document = document
+
+
 class IDocumentCollection(Interface):
     """A collection of documents."""
 
@@ -62,54 +69,54 @@ class IDocumentCollection(Interface):
         """Close the collection. This method may be called more than once, and
         if it doesn't raise an exception on the first time, it should not
         raise an exception the next times it is called.
-        
+
         """
 
     def insert(document):
         """Store a new document in the collection and return a deferred that
         will fire with the ID of the newly added document once the document
         has been successfully inserted.
-        
+
         If document has an 'id' key, it is used as the ID. Else, an ID is
         generated and added to the document (the document object passed in
         will be modified). The deferred errback is fired with an
         InvalidIdError if the given ID is already in used. This mean that
         when the deferred fire its callback, document is guaranteed to have
         an 'id' key.
-        
+
         """
 
     def update(document):
         """Update the document with the current document and return a
         deferred that fire with None once the document has been successfully
         updated.
-        
+
         The document must have an 'id' key that is a valid ID in the
         collection, else the deferred will fire its errback with an
         InvalidIdError.
-        
+
         """
 
     def delete(id):
         """Delete the document with the given ID and return a deferred that
         fire with None once the document with the given id has been
         successfully deleted.
-        
+
         The deferred will fire its errback with an InvalidIdError if there's
         no document with the given ID.
-        
+
         """
 
     def retrieve(id):
         """Return a deferred that will fire with the document with the given
         ID, or fire with None if there's no such document.
-        
+
         """
 
     def find(selector, fields, skip, limit, sort):
         """Return a deferred that will fire with an iterator over documents
         that match the selector.
-        
+
         Valid arguments to this method are, in order:
           selector -- a selector (i.e. a dict)
           fields -- a list of fields to include for every matched documents.
@@ -122,29 +129,29 @@ class IDocumentCollection(Interface):
           sort -- a tuple (key, direction), where key is the key to do the sort
             and direction is either 1 for ASC and -1 for DESC. If not specified,
             the matching documents are not sorted.
-        
+
         All arguments are optional except for selector.
-        
+
         """
 
     def find_one(selector):
         """Return a deferred that will fire with the 'first' document that
-        match the selector, or fire with None if there's no document. 
-        
+        match the selector, or fire with None if there's no document.
+
         """
 
     def ensure_index(complex_key):
         """Create an index on the given complex key if it does not already
         exist and return a deferred that fire with None once the index has
         been created.
-        
+
         complex_key has the same format as keys for selectors, i.e. it
         can be of the form 'a.b' for example.
-        
+
         This is an optional operation, and some implementation might not
         implement it, i.e. you should be ready to catch an AttributeError
         when accessing the 'ensure_index' name.
-        
+
         """
 
 
@@ -155,26 +162,26 @@ class IDatabase(Interface):
         """Close the underlying collections and the database. All resources
         used by the collections and the database should be freed after a call
         to this method.
-        
+
         """
 
     def collection(id):
         """Return the collection with the given id.
-        
+
         Raise a ValueError if there's no collection with the given id and/or
         it's not possible to create it.
-        
+
         """
 
 
 class IDatabaseFactory(Interface):
     def new_database(type, generator, **kwargs):
         """Return a new database object.
-        
+
         - type is a string identifying the type of database to create.
-        - generator is a string identifying the type of generator to use.   
-        
+        - generator is a string identifying the type of generator to use.
+
         Raise a ValueError if this factory doesn't recognize type or generator
         as valid values, or if additional arguments are missing or invalid.
-        
+
         """

--- a/provd/rest/api/api.yml
+++ b/provd/rest/api/api.yml
@@ -372,6 +372,8 @@ paths:
       responses:
         '204':
           $ref: '#/responses/NoContentResponse'
+        '403':
+          $ref: '#/responses/ForbiddenResponse'
         '404':
           $ref: '#/responses/NoSuchResourceError'
 
@@ -1070,6 +1072,10 @@ responses:
     description: No content
   UnsupportedMediaError:
     description: Unsupported media type. This error occurs if you forgot to include the Content-Type header
+    schema:
+      $ref: '#/definitions/ErrorMessage'
+  ForbiddenError:
+    description: The operation is not permitted for this resource.
     schema:
       $ref: '#/definitions/ErrorMessage'
   NoSuchResourceError:

--- a/provd/rest/server/server.py
+++ b/provd/rest/server/server.py
@@ -18,7 +18,12 @@ import functools
 import json
 import logging
 from binascii import a2b_base64
-from provd.app import InvalidIdError, DeviceNotInProvdTenantError, TenantInvalidForDeviceError
+from provd.app import (
+    InvalidIdError,
+    DeviceNotInProvdTenantError,
+    TenantInvalidForDeviceError,
+    NonDeletableError,
+)
 from provd.localization import get_locale_and_language
 from provd.operation import format_oip, operation_in_progres_from_deferred
 from provd.persist.common import ID_KEY
@@ -1071,6 +1076,8 @@ class ConfigResource(AuthResource):
         def on_errback(failure):
             if failure.check(InvalidIdError, UnauthorizedTenant):
                 deferred_respond_no_resource(request)
+            elif failure.check(NonDeletableError):
+                deferred_respond_error(request, failure.value, http.FORBIDDEN)
             else:
                 deferred_respond_error(request, failure.value, http.INTERNAL_SERVER_ERROR)
         d = self._app.cfg_delete(self.config_id)


### PR DESCRIPTION
It was possible to delete configurations that had the deletable field
set to False. This created problems when someone deleted the base
configuration by accident and could not get it back.