### PR TITLE
dhcpd-update cron: avoid failling when dhcp is disabled

### DIFF
--- a/debian/wazo-dhcpd-update.cron.d
+++ b/debian/wazo-dhcpd-update.cron.d
@@ -1,2 +1,2 @@
 SHELL=/bin/bash
-0 0 * * 0   root       sleep $[ ( $RANDOM * 3 ) ]s; /usr/sbin/dhcpd-update -dr; systemctl restart isc-dhcp-server.service
+0 0 * * 0   root       sleep $[ ( $RANDOM * 3 ) ]s; /usr/sbin/dhcpd-update -dr; systemctl try-restart isc-dhcp-server.service


### PR DESCRIPTION
Running the DHCP server is optional and should not send a mail to the
administrator.