### PR TITLE
use auth without ssl by default

### DIFF
--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -9,7 +9,8 @@ rest_api:
 auth:
   host: localhost
   port: 9497
-  verify_certificate: /usr/share/xivo-certs/server.crt
+  prefix: null
+  https: false
 amid:
   host: localhost
   port: 9491

--- a/integration_tests/assets/etc/wazo-provd/config.yml
+++ b/integration_tests/assets/etc/wazo-provd/config.yml
@@ -8,5 +8,3 @@ rest_api:
   port: 8666
 auth:
   host: auth
-  port: 9497
-  verify_certificate: False

--- a/provd/config.py
+++ b/provd/config.py
@@ -39,7 +39,8 @@ The following parameters are defined:
     auth:
         host
         port
-        verify_certificate
+        prefix
+        https
         key_file
     database:
         type
@@ -75,8 +76,6 @@ from xivo.config_helper import parse_config_file, read_config_file_hierarchy
 
 logger = logging.getLogger(__name__)
 
-CERT_FILE = '/usr/share/xivo-certs/server.crt'
-
 _DEFAULT_CONFIG = {
     'config_file': '/etc/wazo-provd/config.yml',
     'extra_config_files': '/etc/wazo-provd/conf.d',
@@ -108,7 +107,8 @@ _DEFAULT_CONFIG = {
     'auth': {
         'host': 'localhost',
         'port': 9497,
-        'verify_certificate': CERT_FILE,
+        'prefix': None,
+        'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-provd-key.yml',
     },
     'database': {


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/31

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1689

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1689