### PR TITLE
hardcode basePath in openapi spec

### DIFF
--- a/provd/rest/api/api.yml
+++ b/provd/rest/api/api.yml
@@ -5,7 +5,7 @@ info:
   version: '0.2'
 schemes:
 - https
-basePath: /0.2
+basePath: /api/provd/0.2
 consumes:
   - "application/vnd.proformatique.provd+json"
 produces:


### PR DESCRIPTION
reason: over complicated to hack the file with twisted to dynamically
change the basePath and schemes. It will avoid to mix nginx logic with
daemon.