### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -32,7 +32,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def make_provd(cls, token):
         return Client(
-            'localhost',
+            '127.0.0.1',
             port=cls.service_port(8666, 'provd'),
             version=API_VERSION,
             prefix=None,

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -21,6 +21,6 @@ class TestDocumentation(BaseIntegrationTest):
 
     def test_documentation_errors(self):
         port = self.service_port(8666, 'provd')
-        api_url = 'http://localhost:{port}/0.2/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/0.2/api/api.yml'.format(port=port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6