### PR TITLE
auth verifier: adapt to the new interface of the auth client

### DIFF
--- a/provd/rest/server/auth.py
+++ b/provd/rest/server/auth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import
@@ -7,6 +7,7 @@ import logging
 import requests
 from functools import wraps
 from wazo_auth_client import Client as AuthClient
+from wazo_auth_client.exceptions import InvalidTokenException, MissingPermissionsTokenException
 from xivo import auth_verifier
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,10 @@ class AuthVerifier(auth_verifier.AuthVerifier):
             required_acl = self._required_acl(acl_check, args, kwargs_for_required_acl)
             try:
                 token_is_valid = self.client().token.is_valid(token_id, required_acl, tenant=tenant_uuid)
+            except InvalidTokenException:
+                return self._handle_invalid_token_exception(token_id, required_access=required_acl)
+            except MissingPermissionsTokenException:
+                return self._handle_missing_permissions_token_exception(token_id, required_access=required_acl)
             except requests.RequestException as e:
                 return self.handle_unreachable(e)
 

--- a/provd/servers/http_site.py
+++ b/provd/servers/http_site.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2010-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """This module add support to returning Deferred in Resource getChild/getChildWithDefault.
@@ -66,7 +66,11 @@ class AuthResource(resource.Resource):
         decorated_render_method = auth_verifier.verify_token(self, request, render_method)
         try:
             return decorated_render_method(request)
-        except auth.auth_verifier.Unauthorized:
+        except (
+            auth.auth_verifier.Unauthorized,
+            auth.auth_verifier.InvalidTokenAPIException,
+            auth.auth_verifier.MissingPermissionsTokenAPIException,
+        ):
             request.setResponseCode(http.UNAUTHORIZED)
             return 'Unauthorized'
 


### PR DESCRIPTION
is_valid now returns True or raises an exception

Depends-On: https://github.com/wazo-platform/wazo-auth-client/pull/28
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/96
