### PR TITLE
docker: fix building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Install
 ADD . /usr/src/wazo-provd
 WORKDIR /usr/src/wazo-provd
-RUN pip install -r requirements.txt
-RUN python setup.py install
+# incremental is needed by twisted setup
+RUN pip install incremental==16.10.1 && \
+    pip install -r requirements.txt && \
+    python setup.py install
 
 FROM python:2.7-slim-buster AS build-image
 COPY --from=compile-image /opt/venv /opt/venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ https://github.com/wazo-platform/wazo-amid-client/archive/master.zip
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 https://github.com/wazo-platform/xivo-fetchfw/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
+incremental==16.10.1  # from twisted
 jinja2==2.10
 pyopenssl==19.0.0
 pyyaml==3.13

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ skipsdist = true
 basepython = python2
 commands =
     pytest --junitxml=unit-tests.xml --cov=provd --cov-report term --cov-report xml:coverage.xml provd
+install_command =
+    bash -c "python -m pip install incremental==16.10.1 && python -m pip install $@" -- {opts} {packages}
+allowlist_externals =
+    bash
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
@@ -22,7 +26,8 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 provd > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
+    bash
     sh
 
 [testenv:pylint]
@@ -32,7 +37,8 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
+    bash
     sh
 
 [testenv:integration]
@@ -45,6 +51,7 @@ passenv =
 commands =
     make test-setup
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
+    bash
     make
     sh


### PR DESCRIPTION
How:

* Twisted seems to download the latest version of the lib "incremental"
by itself, without regards for the constraints in requirements.txt.
* When installing typing from requirements.txt, Twisted loads "incremental"
before typing is even installed by pip