### PR TITLE
devices: fix devices list when a key is missing

### DIFF
--- a/integration_tests/suite/test_devices.py
+++ b/integration_tests/suite/test_devices.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -44,6 +44,11 @@ class TestDevices(BaseIntegrationTest):
     def test_list(self):
         results = self._client.devices.list()
         assert_that(results, has_key('devices'))
+
+    def test_list_params(self):
+        broken_device = {'mac': 'aa:bb:cc:dd:ee:ff', 'plugin': None}
+        self._client.devices.create(broken_device)
+        results = self._client.devices.list(sort='ip', sort_ord='ASC', reverse=True)
 
     def test_add(self):
         result_add = self._add_device('10.10.10.10', '00:11:22:33:44:55', id_='1234abcdef1234')

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -276,8 +276,8 @@ class SimpleBackendDocumentCollection:
                 for cur_key in split_key:
                     cur_elem = cur_elem[cur_key]
             except (KeyError, TypeError):
-                # document does not have the given key -- return None
-                return None
+                # document does not have the given key -- return ''
+                return ''
             return cur_elem
 
         return func


### PR DESCRIPTION
Explanation: Python 3 is more strict on comparisons than Python 2, so it raised an exception when a key was not present in a device JSON. For example, if we tried to sort the devices by ip but one of the devices did not have the key:value at all, there would be the following exception:
"TypeError: '<' not supported between instances of 'NoneType' and 'str'"