### PR TITLE
Fix sorting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Running unit tests
 
 ```bash
-apt-get install python-dev libffi-dev libssl-dev
+apt-get install python3-dev libffi-dev libssl-dev
 pip install tox
-tox --recreate -e py27
+tox --recreate -e py37
 ```

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -114,9 +114,11 @@ class TestUtil(unittest.TestCase):
             {'integer_field': 5},
             {'integer_field': -3},
             {'integer_field': 1},
+            {'integer_field': 0},
         ]
         expected_l = [
             {'integer_field': -3},
+            {'integer_field': 0},
             {'integer_field': 1},
             {'integer_field': 5},
         ]
@@ -126,13 +128,13 @@ class TestUtil(unittest.TestCase):
         # trying to sort on an existing field (None)
         l = [
             {'field': 'A'},
-            {'field': 'B'},
             {'field': None},
+            {'field': 'B'},
         ]
         expected_l = [
-            {'field': None},
             {'field': 'A'},
             {'field': 'B'},
+            {'field': None},
         ]
         l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)
@@ -140,28 +142,45 @@ class TestUtil(unittest.TestCase):
     def test_new_key_fun_from_key_field_missed(self):
         # trying to sort on a missing field (string type)
         l = [
-            {'string_field': 'c'},
+            {'string_field': 'b'},
             {},
             {'string_field': 'a'},
         ]
         expected_l = [
-            {},
             {'string_field': 'a'},
-            {'string_field': 'c'},
+            {'string_field': 'b'},
+            {},
         ]
         l.sort(key=_new_key_fun_from_key('string_field'))
         self.assertListEqual(l, expected_l)
 
         # trying to sort on a missing field (integer type)
         l = [
-            {'integer_field': 1},
             {'integer_field': 5},
             {},
+            {'integer_field': 1},
         ]
         expected_l = [
-            {},
             {'integer_field': 1},
             {'integer_field': 5},
+            {},
         ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
+        self.assertListEqual(l, expected_l)
+
+    def test_new_key_fun_from_key_types_not_allowed(self):
+        # trying to sort on a field having not allowed types
+        l = [
+            {'field': {}},
+            {'field': 'a'},
+            {'field': []},
+            {'field': 'b'},
+        ]
+        expected_l = [
+            {'field': 'a'},
+            {'field': 'b'},
+            {'field': []},
+            {'field': {}},
+        ]
+        l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -6,7 +6,8 @@ import unittest
 from provd.persist.util import (
     _retrieve_doc_values,
     _create_pred_from_selector,
-    _new_key_fun_from_key)
+    _new_key_fun_from_key,
+)
 
 
 class TestSelectorSelectValue(unittest.TestCase):
@@ -32,8 +33,7 @@ class TestSelectorSelectValue(unittest.TestCase):
 
     def test_select_value_list(self):
         doc = {'k': ['v1', 'v2']}
-        self.assertEqual([['v1', 'v2']],
-                         list(_retrieve_doc_values('k', doc)))
+        self.assertEqual([['v1', 'v2']], list(_retrieve_doc_values('k', doc)))
 
     def test_select_value_dict_inside_list(self):
         doc = {'k': [{'kk': 'v'}]}
@@ -41,8 +41,7 @@ class TestSelectorSelectValue(unittest.TestCase):
 
     def test_select_value_dict_inside_list_multiple_values(self):
         doc = {'k': [{'kk': 'v1'}, {'kk': 'v2'}]}
-        self.assertEqual(['v1', 'v2'],
-                         list(_retrieve_doc_values('k.kk', doc)))
+        self.assertEqual(['v1', 'v2'], list(_retrieve_doc_values('k.kk', doc)))
 
 
 class TestSelectorCreatePredicate(unittest.TestCase):
@@ -98,52 +97,52 @@ class TestUtil(unittest.TestCase):
     def test_new_key_fun_from_key_field_exists(self):
         # trying to sort on a existing field (string type)
         l = [
-            {'string_field': 'b', 'none_field': None,'integer_field':5},
-            {'string_field': 'a', 'none_field': None,'integer_field':-3},
+            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
+            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            ]
+        ]
         expected_l = [
-            {'string_field': 'a', 'none_field': None,'integer_field':-3},
-            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
+            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            ]
+        ]
         l.sort(key=_new_key_fun_from_key('string_field'))
-        self.assertListEqual(l,expected_l)
+        self.assertListEqual(l, expected_l)
 
         # trying to sort on a existing field (integer type)
         expected_l = [
-            {'string_field': 'a', 'none_field': None,'integer_field':-3},
+            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None,'integer_field':5},
-            ]
+            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
+        ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
-        self.assertListEqual(l,expected_l)
+        self.assertListEqual(l, expected_l)
 
     def test_new_key_fun_from_key_field_missed(self):
         # trying to sort on a missing field (string type)
         l = [
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'none_field': None,'integer_field':5},
-            {'string_field': 'a', 'none_field': None,'integer_field':3},
-            ]
+            {'none_field': None, 'integer_field': 5},
+            {'string_field': 'a', 'none_field': None, 'integer_field': 3},
+        ]
         expected_l = [
-            {'none_field': None,'integer_field':5},
-            {'string_field': 'a', 'none_field': None,'integer_field':3},
+            {'none_field': None, 'integer_field': 5},
+            {'string_field': 'a', 'none_field': None, 'integer_field': 3},
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            ]
+        ]
         l.sort(key=_new_key_fun_from_key('string_field'))
-        self.assertListEqual(l,expected_l)
+        self.assertListEqual(l, expected_l)
 
         # trying to sort on a missing field (integer type)
         l = [
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
             {'string_field': 'a', 'none_field': None},
-            ]
+        ]
         expected_l = [
             {'string_field': 'a', 'none_field': None},
             {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None,'integer_field':5},
-            ]
+            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
+        ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
-        self.assertListEqual(l,expected_l)
+        self.assertListEqual(l, expected_l)

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from provd.persist.util import _retrieve_doc_values, _create_pred_from_selector
+from provd.persist.util import (
+    _retrieve_doc_values,
+    _create_pred_from_selector,
+    _new_key_fun_from_key)
 
 
 class TestSelectorSelectValue(unittest.TestCase):
@@ -89,3 +92,58 @@ class TestSelectorCreatePredicate(unittest.TestCase):
         self.assertFalse(pred({'k': {'foo': 'bar'}}))
         self.assertFalse(pred({'k': [{'kk': 'v1'}]}))
         self.assertFalse(pred({'k': []}))
+
+
+class TestUtil(unittest.TestCase):
+    def test_new_key_fun_from_key_field_exists(self):
+        # trying to sort on a existing field (string type)
+        l = [
+            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            {'string_field': 'a', 'none_field': None,'integer_field':-3},
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            ]
+        expected_l = [
+            {'string_field': 'a', 'none_field': None,'integer_field':-3},
+            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            ]
+        l.sort(key=_new_key_fun_from_key('string_field'))
+        self.assertListEqual(l,expected_l)
+
+        # trying to sort on a existing field (integer type)
+        expected_l = [
+            {'string_field': 'a', 'none_field': None,'integer_field':-3},
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            ]
+        l.sort(key=_new_key_fun_from_key('integer_field'))
+        self.assertListEqual(l,expected_l)
+
+    def test_new_key_fun_from_key_field_missed(self):
+        # trying to sort on a missing field (string type)
+        l = [
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'none_field': None,'integer_field':5},
+            {'string_field': 'a', 'none_field': None,'integer_field':3},
+            ]
+        expected_l = [
+            {'none_field': None,'integer_field':5},
+            {'string_field': 'a', 'none_field': None,'integer_field':3},
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            ]
+        l.sort(key=_new_key_fun_from_key('string_field'))
+        self.assertListEqual(l,expected_l)
+
+        # trying to sort on a missing field (integer type)
+        l = [
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            {'string_field': 'a', 'none_field': None},
+            ]
+        expected_l = [
+            {'string_field': 'a', 'none_field': None},
+            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'string_field': 'b', 'none_field': None,'integer_field':5},
+            ]
+        l.sort(key=_new_key_fun_from_key('integer_field'))
+        self.assertListEqual(l,expected_l)

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2010-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -139,6 +139,20 @@ class TestUtil(unittest.TestCase):
         l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)
 
+        # trying to sort on an existing field (dict type)
+        l = [
+            {'field': {'string_field': 'b'}},
+            {'field': {'string_field': 'a'}},
+            {'field': {'string_field': 'c'}},
+        ]
+        expected_l = [
+            {'field': {'string_field': 'a'}},
+            {'field': {'string_field': 'b'}},
+            {'field': {'string_field': 'c'}},
+        ]
+        l.sort(key=_new_key_fun_from_key('field.string_field'))
+        self.assertListEqual(l, expected_l)
+
     def test_new_key_fun_from_key_field_missed(self):
         # trying to sort on a missing field (string type)
         l = [

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -95,54 +95,73 @@ class TestSelectorCreatePredicate(unittest.TestCase):
 
 class TestUtil(unittest.TestCase):
     def test_new_key_fun_from_key_field_exists(self):
-        # trying to sort on a existing field (string type)
+        # trying to sort on an existing field (string type)
         l = [
-            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
-            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'string_field': 'b'},
+            {'string_field': 'a'},
+            {'string_field': 'c'},
         ]
         expected_l = [
-            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
-            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {'string_field': 'a'},
+            {'string_field': 'b'},
+            {'string_field': 'c'},
         ]
         l.sort(key=_new_key_fun_from_key('string_field'))
         self.assertListEqual(l, expected_l)
 
-        # trying to sort on a existing field (integer type)
+        # trying to sort on an existing field (integer type)
+        l = [
+            {'integer_field': 5},
+            {'integer_field': -3},
+            {'integer_field': 1},
+        ]
         expected_l = [
-            {'string_field': 'a', 'none_field': None, 'integer_field': -3},
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
+            {'integer_field': -3},
+            {'integer_field': 1},
+            {'integer_field': 5},
         ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
+        self.assertListEqual(l, expected_l)
+
+        # trying to sort on an existing field (None)
+        l = [
+            {'field': 'A'},
+            {'field': 'B'},
+            {'field': None},
+        ]
+        expected_l = [
+            {'field': None},
+            {'field': 'A'},
+            {'field': 'B'},
+        ]
+        l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)
 
     def test_new_key_fun_from_key_field_missed(self):
         # trying to sort on a missing field (string type)
         l = [
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'none_field': None, 'integer_field': 5},
-            {'string_field': 'a', 'none_field': None, 'integer_field': 3},
+            {'string_field': 'c'},
+            {},
+            {'string_field': 'a'},
         ]
         expected_l = [
-            {'none_field': None, 'integer_field': 5},
-            {'string_field': 'a', 'none_field': None, 'integer_field': 3},
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
+            {},
+            {'string_field': 'a'},
+            {'string_field': 'c'},
         ]
         l.sort(key=_new_key_fun_from_key('string_field'))
         self.assertListEqual(l, expected_l)
 
         # trying to sort on a missing field (integer type)
         l = [
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
-            {'string_field': 'a', 'none_field': None},
+            {'integer_field': 1},
+            {'integer_field': 5},
+            {},
         ]
         expected_l = [
-            {'string_field': 'a', 'none_field': None},
-            {'string_field': 'c', 'none_field': None, 'integer_field': 1},
-            {'string_field': 'b', 'none_field': None, 'integer_field': 5},
+            {},
+            {'integer_field': 1},
+            {'integer_field': 5},
         ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
         self.assertListEqual(l, expected_l)

--- a/provd/persist/tests/test_persist.py
+++ b/provd/persist/tests/test_persist.py
@@ -109,20 +109,22 @@ class TestUtil(unittest.TestCase):
         l.sort(key=_new_key_fun_from_key('string_field'))
         self.assertListEqual(l, expected_l)
 
-        # trying to sort on an existing field (integer type)
+        # trying to sort on an existing field (integer/float type)
         l = [
-            {'integer_field': 5},
-            {'integer_field': -3},
-            {'integer_field': 1},
-            {'integer_field': 0},
+            {'field': 5},
+            {'field': 1.5},
+            {'field': -3},
+            {'field': 1},
+            {'field': 0},
         ]
         expected_l = [
-            {'integer_field': -3},
-            {'integer_field': 0},
-            {'integer_field': 1},
-            {'integer_field': 5},
+            {'field': -3},
+            {'field': 0},
+            {'field': 1},
+            {'field': 1.5},
+            {'field': 5},
         ]
-        l.sort(key=_new_key_fun_from_key('integer_field'))
+        l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)
 
         # trying to sort on an existing field (None)
@@ -132,9 +134,9 @@ class TestUtil(unittest.TestCase):
             {'field': 'B'},
         ]
         expected_l = [
+            {'field': None},
             {'field': 'A'},
             {'field': 'B'},
-            {'field': None},
         ]
         l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)
@@ -161,9 +163,9 @@ class TestUtil(unittest.TestCase):
             {'string_field': 'a'},
         ]
         expected_l = [
+            {},
             {'string_field': 'a'},
             {'string_field': 'b'},
-            {},
         ]
         l.sort(key=_new_key_fun_from_key('string_field'))
         self.assertListEqual(l, expected_l)
@@ -175,26 +177,9 @@ class TestUtil(unittest.TestCase):
             {'integer_field': 1},
         ]
         expected_l = [
+            {},
             {'integer_field': 1},
             {'integer_field': 5},
-            {},
         ]
         l.sort(key=_new_key_fun_from_key('integer_field'))
-        self.assertListEqual(l, expected_l)
-
-    def test_new_key_fun_from_key_types_not_allowed(self):
-        # trying to sort on a field having not allowed types
-        l = [
-            {'field': {}},
-            {'field': 'a'},
-            {'field': []},
-            {'field': 'b'},
-        ]
-        expected_l = [
-            {'field': 'a'},
-            {'field': 'b'},
-            {'field': []},
-            {'field': {}},
-        ]
-        l.sort(key=_new_key_fun_from_key('field'))
         self.assertListEqual(l, expected_l)

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -564,8 +564,8 @@ def _new_key_fun_from_key(key):
         cur_elem = document
         try:
             for cur_key in split_key:
-                cur_elem = cur_elem[cur_key]
-        except (KeyError, TypeError) as e:
+                cur_elem = cur_elem.get(cur_key, '') or ''
+        except AttributeError as e:
             return ''
         return str(cur_elem)
 

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -73,7 +73,9 @@ def _new_in_matcher(s_value):
     # Return a matcher that returns true if there's a value in the document
     # matching the select key that is equal to one of the value in s_value
     if not isinstance(s_value, list):
-        raise ValueError(f'selector value for in matcher must be a list: {s_value} is not')
+        raise ValueError(
+            f'selector value for in matcher must be a list: {s_value} is not'
+        )
     pred = lambda doc_value: doc_value in s_value
     return _new_simple_matcher_from_pred(pred)
 
@@ -89,7 +91,9 @@ def _new_nin_matcher(s_value):
     # Return a matcher that returns true if there's no values in the document
     # matching the select key that is equal to one of the value in s_value
     if not isinstance(s_value, list):
-        raise ValueError(f'Selector value for nin matcher must be a list: {s_value} is not')
+        raise ValueError(
+            f'Selector value for nin matcher must be a list: {s_value} is not'
+        )
     pred = lambda doc_value: doc_value in s_value
     return _new_simple_inv_matcher_from_pred(pred)
 
@@ -237,7 +241,9 @@ class SimpleBackendDocumentCollection:
         try:
             document_id = document[ID_KEY]
         except KeyError:
-            return defer.fail(ValueError(f'no {ID_KEY} key found in document {document}'))
+            return defer.fail(
+                ValueError(f'no {ID_KEY} key found in document {document}')
+            )
         else:
             if document_id not in self._backend:
                 return defer.fail(InvalidIdError(document_id))
@@ -326,6 +332,7 @@ class SimpleBackendDocumentCollection:
         if not limit:
             return documents
         else:
+
             def func(limit):
                 # limit is an argument to aux, else it will raise an
                 # UnboundLocalVariable exception (since we are using python 2)
@@ -370,8 +377,7 @@ class SimpleBackendDocumentCollection:
         indexes_selector = {}
         regular_selector = {}
         for selector_key, selector_value in selector.items():
-            if (selector_key in self._indexes and
-                    not _contains_operator(selector_value)):
+            if selector_key in self._indexes and not _contains_operator(selector_value):
                 indexes_selector[selector_key] = selector_value
             else:
                 regular_selector[selector_key] = selector_value
@@ -387,7 +393,11 @@ class SimpleBackendDocumentCollection:
 
     def _do_find_unsorted(self, selector, fields, skip, limit):
         # common case optimization when only ID_KEY is present
-        if ID_KEY in selector and len(selector) == 1 and not _contains_operator(selector[ID_KEY]):
+        if (
+            ID_KEY in selector
+            and len(selector) == 1
+            and not _contains_operator(selector[ID_KEY])
+        ):
             try:
                 documents = [self._backend[selector[ID_KEY]]]
             except KeyError:
@@ -407,13 +417,19 @@ class SimpleBackendDocumentCollection:
             return self._do_find_unsorted(selector, fields, skip, limit)
 
     def find(self, selector, fields=None, skip=0, limit=0, sort=None):
-        logger.debug('Executing find in backend based collection with:\n'
-                     '  selector: %s\n'
-                     '  fields: %s\n'
-                     '  skip: %s\n'
-                     '  limit: %s\n'
-                     '  sort: %s',
-                     selector, fields, skip, limit, sort)
+        logger.debug(
+            'Executing find in backend based collection with:\n'
+            '  selector: %s\n'
+            '  fields: %s\n'
+            '  skip: %s\n'
+            '  limit: %s\n'
+            '  sort: %s',
+            selector,
+            fields,
+            skip,
+            limit,
+            sort,
+        )
         return defer.succeed(self._do_find(selector, fields, skip, limit, sort))
 
     def find_one(self, selector):
@@ -535,6 +551,7 @@ class ForwardingDocumentCollection:
 
     def __getattr__(self, name):
         return getattr(self._collection, name)
+
 
 def _new_key_fun_from_key(key):
     # Return a function usable for the key parameter of the sorted function

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -554,8 +554,10 @@ class ForwardingDocumentCollection:
 
 
 def _new_key_fun_from_key(key):
-    # Return a function usable for the key parameter of the sorted function
-    # from a [sort] key
+    """
+    Return a function usable for the key parameter of the sorted function
+    from a [sort] key
+    """
     split_key = key.split('.')
 
     def func(document):

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -564,9 +564,11 @@ def _new_key_fun_from_key(key):
         cur_elem = document
         try:
             for cur_key in split_key:
-                cur_elem = cur_elem.get(cur_key, '') or ''
-        except AttributeError as e:
-            return ''
-        return str(cur_elem)
+                cur_elem = cur_elem[cur_key]
+        except (KeyError, TypeError) as e:
+            return False, str(cur_elem)
+        # if the value is not a str/int/float, then return (True, str(cur_elem))
+        # as False < True, the value that is not a str/int/float is put at the end
+        return type(cur_elem) not in (str, int, float), str(cur_elem)
 
     return func

--- a/provd/persist/util.py
+++ b/provd/persist/util.py
@@ -566,9 +566,7 @@ def _new_key_fun_from_key(key):
             for cur_key in split_key:
                 cur_elem = cur_elem[cur_key]
         except (KeyError, TypeError) as e:
-            return False, str(cur_elem)
-        # if the value is not a str/int/float, then return (True, str(cur_elem))
-        # as False < True, the value that is not a str/int/float is put at the end
-        return type(cur_elem) not in (str, int, float), str(cur_elem)
+            return ''
+        return '' if cur_elem is None else str(cur_elem)
 
     return func

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ cryptography>=2.1.4 # for pyopenssl
 pyyaml==3.13
 requests==2.21.0
 stevedore==1.29.0
-twisted==18.9.0
+twisted==19.7.0
 zope.interface==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ cryptography>=2.1.4 # for pyopenssl
 pyyaml==3.13
 requests==2.21.0
 stevedore==1.29.0
-twisted==19.7.0
+twisted==18.9.0
 zope.interface==4.7.2


### PR DESCRIPTION
1. sorting error
`builtins.TypeError: '<' not supported between instances of 'int' and 'str'`
Appears when the field is an integer and not a string.



2. twisted has been updated to 19.7.0, due to error when executing unit tests:

```
Could not find a version that satisfies the requirement twisted==18.9.0 (from versions: 19.7.0, 19.10.0, 20.3.0, 21.2.0rc1, 21.2.0, 21.7.0rc1, 21.7.0rc2, 21.7.0rc3, 21.7.0, 22.1.0rc1, 22.1.0, 22.2.0rc1, 22.2.0, 22.4.0rc1, 22.4.0, 22.8.0rc1, 22.8.0, 22.10.0rc1, 22.10.0)
ERROR: No matching distribution found for twisted==18.9.0

``` 