### PR TITLE
config: use num_http_proxies = 1

### DIFF
--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -3,9 +3,10 @@ general:
   http_port: 18667
   tftp_port: 69
   sync_service_type: 'asterisk_ami'
-  # num_http_proxies before wazo-provd. used to detect the device's IP address
-  # if 0 X-Forwarded-For header will be ignored
-  # num_http_proxies: 0
+  # Number of trusted HTTP reverse-proxies before a phone can reach
+  # wazo-provd. This is used to detect the device's IP address.
+  # If 0, then the HTTP header X-Forwarded-For will be ignored.
+  num_http_proxies: 1
 rest_api:
   ip: 127.0.0.1
   port: 8666


### PR DESCRIPTION
Why:

* Now that nginx is used to reverse-proxy requests to wazo-provd, we
  need to trust the IP address of the request to nginx in order to
  detect the IP address of the phone