### PR TITLE
[WAZO-3420] config: revert changes to HTTP ports

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-wazo-provd (23.13~20230915.100720) wazo-dev-bullseye; urgency=medium
-
-  * Add nginx provisioning reverse proxy
-
- -- Wazo Maintainers <dev+pkg@wazo.community>  Fri, 15 Sep 2023 10:07:20 -0400
-
 wazo-provd (21.14~20211018.112050) wazo-dev-buster; urgency=medium
 
   * Refactor syntax to be python2.7 and python3 compatible

--- a/debian/wazo-provd.dirs
+++ b/debian/wazo-provd.dirs
@@ -2,4 +2,3 @@ etc/wazo-provd/conf.d
 var/lib/wazo-provd
 var/cache/wazo-provd
 etc/nginx/locations/https-enabled
-etc/nginx/sites-enabled

--- a/debian/wazo-provd.install
+++ b/debian/wazo-provd.install
@@ -1,4 +1,3 @@
 etc/nginx/locations/* etc/nginx/locations
-etc/nginx/sites-available/* etc/nginx/sites-available
 etc/wazo-provd/*  etc/wazo-provd
 debian/tmp/usr/lib usr/

--- a/debian/wazo-provd.links
+++ b/debian/wazo-provd.links
@@ -1,1 +1,0 @@
-etc/nginx/sites-available/wazo-provd etc/nginx/sites-enabled/wazo-provd

--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -1,7 +1,8 @@
 general:
   external_ip: 127.0.0.1
-  http_port: 18667
-  listen_interface: 127.0.0.1
+  http_port: 8667
+  listen_interface: 0.0.0.0
+  listen_port: 8667
   tftp_port: 69
   sync_service_type: 'asterisk_ami'
   # Number of trusted HTTP reverse-proxies before a phone can reach

--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -8,7 +8,7 @@ general:
   # Number of trusted HTTP reverse-proxies before a phone can reach
   # wazo-provd. This is used to detect the device's IP address.
   # If 0, then the HTTP header X-Forwarded-For will be ignored.
-  num_http_proxies: 1
+  num_http_proxies: 0
 rest_api:
   ip: 127.0.0.1
   port: 8666

--- a/provd/config.py
+++ b/provd/config.py
@@ -102,7 +102,7 @@ _DEFAULT_CONFIG = {
         'base_external_url': f'http://localhost:{DEFAULT_HTTP_PORT}',
         'verbose': False,
         'sync_service_type': 'none',
-        'num_http_proxies': 1,
+        'num_http_proxies': 0,
     },
     'rest_api': {
         'ip': '127.0.0.1',

--- a/provd/config.py
+++ b/provd/config.py
@@ -76,7 +76,7 @@ from xivo.config_helper import parse_config_file, read_config_file_hierarchy
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_LISTEN_PORT = 18667
+DEFAULT_LISTEN_PORT = 8667
 DEFAULT_HTTP_PORT = 8667
 
 _DEFAULT_CONFIG = {
@@ -84,7 +84,7 @@ _DEFAULT_CONFIG = {
     'extra_config_files': '/etc/wazo-provd/conf.d',
     'general': {
         'external_ip': '127.0.0.1',
-        'listen_interface': '127.0.0.1',
+        'listen_interface': '0.0.0.0',
         'listen_port': DEFAULT_LISTEN_PORT,
         'base_raw_config_file': '/etc/wazo-provd/base_raw_config.json',
         'request_config_dir': '/etc/wazo-provd',

--- a/provd/config.py
+++ b/provd/config.py
@@ -76,7 +76,8 @@ from xivo.config_helper import parse_config_file, read_config_file_hierarchy
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HTTP_PORT = 18667
+DEFAULT_LISTEN_PORT = 18667
+DEFAULT_HTTP_PORT = 8667
 
 _DEFAULT_CONFIG = {
     'config_file': '/etc/wazo-provd/config.yml',
@@ -84,6 +85,7 @@ _DEFAULT_CONFIG = {
     'general': {
         'external_ip': '127.0.0.1',
         'listen_interface': '127.0.0.1',
+        'listen_port': DEFAULT_LISTEN_PORT,
         'base_raw_config_file': '/etc/wazo-provd/base_raw_config.json',
         'request_config_dir': '/etc/wazo-provd',
         'cache_dir': '/var/cache/wazo-provd',

--- a/provd/main.py
+++ b/provd/main.py
@@ -163,7 +163,7 @@ class HTTPProcessService(Service):
         http_process_service = ident.HTTPRequestProcessingService(process_service, app.pg_mgr, num_http_proxies)
         site = Site(http_process_service)
         interface = self._config['general']['listen_interface']
-        port = self._config['general']['http_port']
+        port = self._config['general']['listen_port']
         logger.info('Binding HTTP provisioning service to port %s', port)
         self._tcp_server = internet.TCPServer(port, site, backlog=128, interface=interface)
         self._tcp_server.startService()


### PR DESCRIPTION
Why: internal (provd-nginx) port and external (from nginx) ports
are not the same but the phones need to know the second (from nginx) port
because it's the one that is exposed.
The public port (http_port in the configuration) is used by phones for their provisioning URL. It should thus not be the private port.

It is necessary to revert the changes to both provd and the database to be able to provision phones correctly. Also, removing the nginx reverse proxy for now is the solution.

See [xivo-manage-db](https://github.com/wazo-platform/xivo-manage-db/pull/228) for the database correction.
See [xivo-config](https://github.com/wazo-platform/xivo-config/pull/90) for the configuration correction.