### PR TITLE
Pull request for WAZO-3502-simplify-provd-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 23.17
+
+* The following configurations have been removed in favor of
+  `advertised_http_url`:
+
+  * `advertised_host`
+  * `advertised_http_port`
+
 ## 23.16
 
 * The following configurations have been renamed:

--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -1,7 +1,5 @@
 general:
-  advertised_host: 127.0.0.1
-  advertised_http_port: 8667
-  advertised_http_url: null
+  advertised_http_url: http://127.0.0.1:8667
   tftp_port: 69
   http_proxied_listen_interface: 127.0.0.1
   http_proxied_listen_port: 18667

--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -28,8 +28,8 @@ amid:
   prefix: null
   https: false
 bus:
-    username: guest
-    password: guest
-    host: localhost
-    port: 5672
-    exchange_name: wazo-headers
+  username: guest
+  password: guest
+  host: localhost
+  port: 5672
+  exchange_name: wazo-headers

--- a/provd/app.py
+++ b/provd/app.py
@@ -316,12 +316,7 @@ class ProvisioningApplication:
             )
 
             raw_config = copy.deepcopy(raw_config)
-            http_base_url = raw_config.get('http_base_url')
-            if not http_base_url:
-                host = raw_config['ip']
-                port = raw_config['http_port']
-                http_base_url = f'http://{host}:{port}'
-            # Inject the provisioning key into the device configuration
+            http_base_url = raw_config['http_base_url']
             raw_config['http_base_url'] = f'{http_base_url}/{provisioning_key}'
 
         try:

--- a/provd/config.py
+++ b/provd/config.py
@@ -318,18 +318,16 @@ def _update_general_base_raw_config(app_raw_config: dict[str, Any]) -> None:
     # warning: raw_config in the function name means device raw config and
     # the app_raw_config argument means application configuration.
     base_raw_config = app_raw_config['general']['base_raw_config']
-    base_raw_config |= {
-        'http_port': app_raw_config['general']['advertised_http_port'],
-        'tftp_port': app_raw_config['general']['tftp_port'],
-    }
-    if app_raw_config['general']['advertised_http_url']:
-        base_raw_config |= {
-            'http_base_url': app_raw_config['general']['advertised_http_url'],
-        }
-
+    if 'http_port' not in base_raw_config:
+        base_raw_config['http_port'] = app_raw_config['general']['advertised_http_port']
+    if 'tftp_port' not in base_raw_config:
+        base_raw_config['tftp_port'] = app_raw_config['general']['tftp_port']
+    if 'http_base_url' not in base_raw_config:
+        base_raw_config['http_base_url'] = app_raw_config['general'][
+            'advertised_http_url'
+        ]
     if 'ip' not in base_raw_config:
-        advertised_host = app_raw_config['general']['advertised_host']
-        base_raw_config['ip'] = advertised_host
+        base_raw_config['ip'] = app_raw_config['general']['advertised_host']
 
 
 def _post_update_raw_config(raw_config: dict[str, Any]) -> None:

--- a/provd/config.py
+++ b/provd/config.py
@@ -69,6 +69,8 @@ from __future__ import annotations
 import logging
 import json
 import os.path
+
+from urllib.parse import urlparse
 from typing import Any, TypedDict, Union, cast, Literal
 
 from twisted.python import usage
@@ -314,6 +316,12 @@ def _update_general_base_raw_config(app_raw_config: dict[str, Any]) -> None:
         base_raw_config['http_base_url'] = app_raw_config['general'][
             'advertised_http_url'
         ]
+    # Compatibility for plugins released before 23.17
+    if 'ip' not in base_raw_config:
+        base_raw_config['ip'] = urlparse(base_raw_config['http_base_url']).hostname
+    if 'http_port' not in base_raw_config:
+        extracted_port = urlparse(base_raw_config['http_base_url']).port
+        base_raw_config['http_port'] = extracted_port or '8667'
 
 
 def _post_update_raw_config(raw_config: dict[str, Any]) -> None:

--- a/provd/config.py
+++ b/provd/config.py
@@ -247,7 +247,6 @@ _OPTION_TO_PARAM_LIST = [
     # (<option name, (<section, param name>)>)
     ('config-file', ('general', 'config_file')),
     ('config-dir', ('general', 'request_config_dir')),
-    ('http-port', ('general', 'advertised_http_port')),
     ('tftp-port', ('general', 'tftp_port')),
     ('rest-port', ('general', 'rest_port')),
 ]
@@ -276,7 +275,6 @@ class Options(usage.Options):
             None,
             'The directory where request processing configuration file can be found',
         ),
-        ('http-port', None, None, 'The HTTP port to listen on.'),
         ('tftp-port', None, None, 'The TFTP port to listen on.'),
         ('rest-port', None, None, 'The port to listen on.'),
     ]

--- a/provd/config.py
+++ b/provd/config.py
@@ -27,10 +27,6 @@ The following parameters are defined:
         verbose
         sync_service_type
         asterisk_ami_servers
-        advertised_host
-            The hostname of the provisioning server advertised to phones
-        advertised_http_port
-            The HTTP port advertised to phones
         advertised_http_url
             The HTTP URL advertised to phones
     rest_api:
@@ -98,9 +94,7 @@ class GeneralConfig(TypedDict):
     http_proxied_listen_interface: str
     http_proxied_listen_port: int
     http_proxied_trusted_proxies_count: int
-    advertised_host: Union[str, None]
     advertised_http_url: Union[str, None]
-    advertised_http_port: int
     base_raw_config: dict[str, Any]
     base_raw_config_file: str
     request_config_dir: str
@@ -178,8 +172,6 @@ _DEFAULT_CONFIG: ProvdConfigDict = {
     'config_file': '/etc/wazo-provd/config.yml',
     'extra_config_files': '/etc/wazo-provd/conf.d',
     'general': {
-        'advertised_host': '127.0.0.1',
-        'advertised_http_port': 8667,
         'advertised_http_url': None,
         'base_raw_config': {},
         'base_raw_config_file': '/etc/wazo-provd/base_raw_config.json',
@@ -316,16 +308,12 @@ def _update_general_base_raw_config(app_raw_config: dict[str, Any]) -> None:
     # warning: raw_config in the function name means device raw config and
     # the app_raw_config argument means application configuration.
     base_raw_config = app_raw_config['general']['base_raw_config']
-    if 'http_port' not in base_raw_config:
-        base_raw_config['http_port'] = app_raw_config['general']['advertised_http_port']
     if 'tftp_port' not in base_raw_config:
         base_raw_config['tftp_port'] = app_raw_config['general']['tftp_port']
     if 'http_base_url' not in base_raw_config:
         base_raw_config['http_base_url'] = app_raw_config['general'][
             'advertised_http_url'
         ]
-    if 'ip' not in base_raw_config:
-        base_raw_config['ip'] = app_raw_config['general']['advertised_host']
 
 
 def _post_update_raw_config(raw_config: dict[str, Any]) -> None:

--- a/provd/devices/config.py
+++ b/provd/devices/config.py
@@ -68,7 +68,7 @@ _comment [optional]
   Used as a standard way to add a human-readable comment in the raw config.
   This value MUST be ignored by plugins.
 
-ip [mandatory]
+ip [deprecated. Use http_base_url instead]
   The IP address or domain name of the provisioning server.
   If the followings are true:
   - this value represent a domain name
@@ -80,7 +80,7 @@ ip [mandatory]
   your devices support it or be prepared to see incorrect behaviour from
   your devices.
 
-http_port [mandatory if tftp_port is not defined]
+http_port [deprecated. Use http_base_url instead]
   The provisioning server HTTP port number.
   If the followings are true:
   - this value is defined
@@ -92,20 +92,20 @@ http_port [mandatory if tftp_port is not defined]
   If the device only support HTTP yet this value is not defined, an Exception
   SHOULD be raised.
 
-http_base_url [optional]
+http_base_url [mandatory]
   Used in place of the ip and http_port to be able to define the URL at which
   the provisioning server is accessible from. This allows to set the provisioning
   server behind a reverse proxy.
   If you are using a `url_key` strategy for provisioning authentication (provisioning
   key), then you MUST use this setting as the key is appended to this value.
-  This option has precedence over the ip + http_port combination.
+  This option has precedence over the deprecated ip + http_port combination.
 
-tftp_port [mandatory if http_port is not defined]
+tftp_port [mandatory if http_base_url is not defined]
   The provisioning server TFTP port number.
   If the followings are true:
   - this value is defined
   - the device supports retrieving its configuration file via TFTP
-  - the http_port parameter is not defined or the device does not support
+  - the http_base_url parameter is not defined or the device does not support
     retrieving its configuration file via HTTP
   then:
   - the device MUST be configured to use TFTP to retrieve its configuration


### PR DESCRIPTION
## fix base_raw_config override

why: previous logic was a wrong refactor that break the base_raw_config
logic by overriding base_raw_config with app_raw_config. But we want to
override app_raw_config with base_raw_config

## config: use same indent as other keys


## remove http-port from cli option

why: this option doesn't modify anymore the listening port

## remove config advertised_host/http_port

why: is was redundant with advertised_http_url