### PR TITLE
schemas: remove mandatory http_port and tftp_port validators

### DIFF
--- a/provd/devices/schemas.py
+++ b/provd/devices/schemas.py
@@ -219,7 +219,7 @@ def validate_values(cls: type[BaseModel], values: dict[str, Any]) -> dict[str, A
 RawConfigSchema = create_model_from_typeddict(
     RawConfigDict,
     {
-        "ip": Field(...),
+        "ip": Field(),
         "funckeys": Field(default_factory=dict),
         "locale": Field(regex=r'[a-z]{2}_[A-Z]{2}'),
         "syslog_port": Field(514),

--- a/provd/devices/schemas.py
+++ b/provd/devices/schemas.py
@@ -199,9 +199,6 @@ def validate_numeric_keys(
 
 @root_validator(allow_reuse=True)
 def validate_values(cls: type[BaseModel], values: dict[str, Any]) -> dict[str, Any]:
-    if not values.get('tft_port') and not values.get('http_port'):
-        raise ValueError('You must define either `tftp_port` or `http_port`.')
-
     required_if_enabled = (
         ('dns', 'ip'),
         ('ntp', 'ip'),

--- a/provd/devices/tests/test_config.py
+++ b/provd/devices/tests/test_config.py
@@ -50,7 +50,6 @@ def test_raw_config_schema_missing_values() -> None:
     error = exc_trace.value
     assert isinstance(error, ValidationError)
     assert error.errors() == [
-        {'loc': ('ip',), 'msg': 'field required', 'type': 'value_error.missing'},
         {
             'loc': ('sip_lines', '1', 'password'),
             'msg': 'field required',

--- a/provd/devices/tests/test_config.py
+++ b/provd/devices/tests/test_config.py
@@ -61,11 +61,6 @@ def test_raw_config_schema_missing_values() -> None:
             'msg': 'field required',
             'type': 'value_error.missing',
         },
-        {
-            'loc': ('__root__',),
-            'msg': 'You must define either `tftp_port` or `http_port`.',
-            'type': 'value_error',
-        },
     ]
 
 
@@ -118,11 +113,6 @@ def test_raw_config_invalid() -> None:
         {
             'loc': ('funckeys', 'alpha', '__root__'),
             'msg': 'Value is required for BLF and Speed Dial types.',
-            'type': 'value_error',
-        },
-        {
-            'loc': ('__root__',),
-            'msg': 'You must define either `tftp_port` or `http_port`.',
             'type': 'value_error',
         },
     ]


### PR DESCRIPTION
Why: it does not make sense to make it mandatory everywhere. It can be
defined in a template that is inherited by children that don't need to
redefine it.