### PR TITLE
WAZO-3691 http: handle error when GET /$key with no file

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,4 +1,5 @@
 PROVD_DIR ?= ../
+DOCKER_DIR ?= docker
 
 test-setup: egg-info provd provd-test
 
@@ -7,6 +8,7 @@ provd:
 
 provd-test:
 	docker build --no-cache -t wazo-provd-tests -f Dockerfile $(PROVD_DIR)
+	docker build --no-cache -t wazo-provd-plugin-server -f $(DOCKER_DIR)/Dockerfile-http-server $(DOCKER_DIR)
 
 test:
 	pytest -x -vvv

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "69/udp"
 
   pluginserver:
-    image: trinitronx/python-simplehttpserver
+    image: wazo-provd-plugin-server
     volumes:
       - "./plugins/pkgs:/var/www"
     ports:

--- a/integration_tests/docker/Dockerfile-http-server
+++ b/integration_tests/docker/Dockerfile-http-server
@@ -1,0 +1,6 @@
+FROM python:3.10
+
+WORKDIR /var/www
+EXPOSE 8080/tcp
+
+CMD [ "python", "-m", "http.server", "8080"]

--- a/wazo_provd/devices/ident.py
+++ b/wazo_provd/devices/ident.py
@@ -873,28 +873,33 @@ class HTTPKeyVerifyingHook(BaseHTTPHookService):
         logger.debug(
             'URL key verifying hook, path = "%s", request = "%s"', path, request
         )
+
         prov_key = path.decode('utf-8')
         logger.debug('Prov key = "%s"', prov_key)
+
         if not prov_key:
             logger.info('Empty provisioning key. Denying request.')
             return self.unauthorized_resource
+
         tenant_uuid = self._app.configure_service.get_tenant_from_provisioning_key(
             prov_key
         )
         if not tenant_uuid:
             logger.info('Invalid URL key. Denying request.')
             return self.unauthorized_resource
+
         # Inject tenant_uuid in request object
         request.tenant_uuid = tenant_uuid
 
-        request.postpath.insert(0, path)
-        request.prepath.pop()
+        logger.debug(
+            'Received request: path = %s, prepath = %s, postpath = %s',
+            path,
+            request.prepath,
+            request.postpath,
+        )
 
-        request.postpath = request.postpath[1:]
-        path = b'/' + b'/'.join(request.prepath + request.postpath)
+        path = self._strip_key_from_request(path, request)
 
-        path = request.postpath.pop(0)
-        request.prepath.append(path)
         logger.debug(
             'Rewritten request: path = %s, prepath = %s, postpath = %s',
             path,
@@ -902,6 +907,20 @@ class HTTPKeyVerifyingHook(BaseHTTPHookService):
             request.postpath,
         )
         return self._next_service(path, request)
+
+    @staticmethod
+    def _strip_key_from_request(path, request):
+        # remove the processed key
+        request.prepath.pop()
+
+        # replace the key with the requested resource
+        try:
+            path = request.postpath.pop(0)
+        except IndexError:
+            path = ''
+        request.prepath.append(path)
+
+        return path
 
 
 # @implementer(ITFTPReadService)

--- a/wazo_provd/devices/tests/test_ident.py
+++ b/wazo_provd/devices/tests/test_ident.py
@@ -15,6 +15,7 @@ from wazo_provd.devices import ident
 from wazo_provd.devices.ident import (
     AddDeviceRetriever,
     DHCPRequest,
+    HTTPKeyVerifyingHook,
     LastSeenUpdater,
     RemoveOutdatedIpDeviceUpdater,
     Request,
@@ -434,3 +435,28 @@ class TestGetIPFromHTTPRequestWithProxies(unittest.TestCase):
         self.assertRaises(
             RuntimeError, _get_ip_from_http_request_with_proxies, self.request, 3
         )
+
+
+class TestHTTPKeyVerifyingHook(unittest.TestCase):
+    def setUp(self) -> None:
+        self.request = Mock()
+
+    def test_strip_key_from_request(self):
+        self.request.prepath = ['my-key']
+        self.request.postpath = ['my-file']
+
+        path = HTTPKeyVerifyingHook._strip_key_from_request('my-key', self.request)
+
+        assert path == 'my-file'
+        assert self.request.prepath == ['my-file']
+        assert self.request.postpath == []
+
+    def test_strip_key_from_empty_request(self):
+        self.request.prepath = ['my-key']
+        self.request.postpath = []
+
+        path = HTTPKeyVerifyingHook._strip_key_from_request('my-key', self.request)
+
+        assert path == ''
+        assert self.request.prepath == ['']
+        assert self.request.postpath == []


### PR DESCRIPTION
Why:

* It returns an error 500 instead of a more standard error
* It can make wazo-provd crash, see WAZO-3686