### PR TITLE
WP-1476 tenant helpers: update logic to reflect upstream

### DIFF
--- a/wazo_provd/app.py
+++ b/wazo_provd/app.py
@@ -33,7 +33,7 @@ from wazo_provd.persist.common import InvalidIdError as PersistInvalidIdError
 from wazo_provd.persist.common import NonDeletableError as PersistNonDeletableError
 from wazo_provd.plugins import PluginManager, PluginNotLoadedError
 from wazo_provd.rest.server import auth
-from wazo_provd.rest.server.helpers.tenants import Tenant, Tokens
+from wazo_provd.rest.server.helpers.tenants import Tenant, tenant_helpers
 from wazo_provd.services import (
     InvalidParameterError,
     JsonConfigPersister,
@@ -261,7 +261,7 @@ class ProvisioningApplication:
         logger.debug('Setting token for provd app: %s', token_id)
         self._token = token_id
         auth_client = auth.get_auth_client()
-        token = Tokens(auth_client).get(self._token)
+        token = tenant_helpers.Token(self._token, auth_client)
         self.set_tenant_uuid(Tenant.from_token(token).uuid)
 
     def tenant_uuid(self) -> str | None:

--- a/wazo_provd/rest/server/helpers/tenants.py
+++ b/wazo_provd/rest/server/helpers/tenants.py
@@ -40,4 +40,4 @@ class Tokens(tenant_helpers.Tokens):
         token_id = decode_bytes(request.getHeader(b'X-Auth-Token'))
         if not token_id:
             raise InvalidToken()
-        return self.get(token_id)
+        return tenant_helpers.Token(token_id, self._auth)

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -4,6 +4,7 @@
       - wazo-tox-linters-310
       - wazo-tox-integration-py39
       - debian-packaging-bullseye
+      - wazo-acceptance-bullseye
     vars:
       docker_compose_services_override:
         - provd


### PR DESCRIPTION
why: get has been removed to make query lazy (when properties are
fetched)

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/137