### PR TITLE
WP-2120-remove-pkg-resources

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ X-Python3-Version: >= 3.11
 Package: wazo-provd
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
+# python3-packaging: used by wazo-provd-plugins
 Depends:
     ${python3:Depends},
     ${misc:Depends},
@@ -16,6 +17,7 @@ Depends:
     python3-jinja2,
     python3-kombu,
     python3-openssl,
+    python3-packaging,
     python3-pydantic,
     python3-twisted,
     unar,


### PR DESCRIPTION
why: used by snom plugin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change adding a runtime dependency; low risk aside from potential dependency resolution differences in downstream builds.
> 
> **Overview**
> Updates Debian packaging for `wazo-provd` to explicitly depend on `python3-packaging` (noted as required by `wazo-provd-plugins`, e.g., the Snom plugin).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6fad40111288c756c1827f0a8fcd84e45bed1ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->