### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "9497"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     container_name: rabbitmq
     ports:
       - "5672"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the integration-test Docker Compose image tag for RabbitMQ; main impact is potential CI/test environment differences if RabbitMQ v3 behavior diverges from `latest`.
> 
> **Overview**
> Pins the integration tests' `rabbitmq` Docker Compose service from the floating `rabbitmq` image to the explicit `rabbitmq:3` tag to make test runs more deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec43a0bbaf31efc554c04812e77eebb622f9723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->