### PR TITLE
[RB-69] [RB-70] misc(systemd): change systemd service from forking to simple

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wazo-provd (26.06) wazo-dev-bookworm; urgency=medium
+
+  * Run the service in the foreground (twistd --nodaemon) under systemd so its
+    logs are captured by journald; switch service Type from forking to simple.
+    File logging to /var/log/wazo-provd.log is unchanged. The PID file is still
+    written for monit.
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Tue, 23 Jun 2026 20:06:19 -0400
+
 wazo-provd (21.14~20211018.112050) wazo-dev-buster; urgency=medium
 
   * Refactor syntax to be python2.7 and python3 compatible

--- a/debian/wazo-provd.service
+++ b/debian/wazo-provd.service
@@ -5,8 +5,7 @@ After=network.target wazo-confgend.service
 Before=monit.service
 
 [Service]
-ExecStartPre=/usr/bin/install -d -o wazo-provd -g wazo-provd /run/wazo-provd
-ExecStart=/usr/bin/twistd3 --nodaemon --pidfile=/run/wazo-provd/wazo-provd.pid --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd
+ExecStart=/usr/bin/twistd3 --nodaemon --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd
 UMask=0077
 Restart=on-failure
 RestartSec=5

--- a/debian/wazo-provd.service
+++ b/debian/wazo-provd.service
@@ -5,10 +5,11 @@ After=network.target wazo-confgend.service
 Before=monit.service
 
 [Service]
-Type=forking
 ExecStartPre=/usr/bin/install -d -o wazo-provd -g wazo-provd /run/wazo-provd
-ExecStart=/usr/bin/twistd3 --pidfile=/run/wazo-provd/wazo-provd.pid --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd
-PIDFile=/run/wazo-provd/wazo-provd.pid
+ExecStart=/usr/bin/twistd3 --nodaemon --pidfile=/run/wazo-provd/wazo-provd.pid --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd
+UMask=0077
+Restart=on-failure
+RestartSec=5
 SyslogIdentifier=wazo-provd
 
 [Install]


### PR DESCRIPTION
why: log to journald, avoid startup timeout on slow database loading

See also https://github.com/wazo-platform/wazo-monitoring/pull/27 for removing from monit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the provisioning daemon is supervised at boot and restart; misconfiguration could affect service availability or monit if it relied on the old PID file path.
> 
> **Overview**
> **wazo-provd** is switched from a **forking** systemd unit to a **simple** foreground service so startup is not tied to a PID file and slow database load is less likely to hit systemd timeouts.
> 
> `ExecStart` now runs `twistd3` with **`--nodaemon`** instead of daemonizing with **`--pidfile`**. The unit drops **`Type=forking`**, **`PIDFile`**, and the **`ExecStartPre`** that created `/run/wazo-provd`. **`UMask=0077`**, **`Restart=on-failure`**, and **`RestartSec=5`** are added. **`SyslogIdentifier=wazo-provd`** is unchanged so stdout/stderr can go to **journald**; the changelog notes file logging to `/var/log/wazo-provd.log` stays as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d0813daa56f03ff2207235fb9ff7235f83bd92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->