### PR TITLE
fix-wait

### DIFF
--- a/debian/wazo-provd.service
+++ b/debian/wazo-provd.service
@@ -3,6 +3,8 @@ Description=wazo-provd server
 ConditionPathExists=!/var/lib/wazo/disabled
 After=network.target wazo-confgend.service
 Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
 ExecStart=/usr/bin/twistd3 --nodaemon --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd

--- a/debian/wazo-provd.service
+++ b/debian/wazo-provd.service
@@ -2,7 +2,6 @@
 Description=wazo-provd server
 ConditionPathExists=!/var/lib/wazo/disabled
 After=network.target wazo-confgend.service
-Before=monit.service
 StartLimitBurst=15
 StartLimitIntervalSec=150
 

--- a/debian/wazo-provd.service
+++ b/debian/wazo-provd.service
@@ -6,6 +6,7 @@ Before=monit.service
 
 [Service]
 ExecStart=/usr/bin/twistd3 --nodaemon --rundir=/ --uid=wazo-provd --gid=wazo-provd --no_save --logger wazo_provd.main.twistd_logs wazo-provd
+ExecStartPost=/usr/bin/wazo-provd-wait
 UMask=0077
 Restart=on-failure
 RestartSec=5

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,9 @@ setup(
         'twisted': ['.noinit'],
         'twisted.plugins': ['provd_plugins.py', '.noinit'],
     },
+    entry_points={
+        'console_scripts': [
+            'wazo-provd-wait=wazo_provd.wait:main',
+        ],
+    },
 )

--- a/wazo_provd/wait.py
+++ b/wazo_provd/wait.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import socket
+import sys
+import time
+from contextlib import closing
+
+from xivo.chain_map import ChainMap
+from xivo.config_helper import read_config_file_hierarchy
+
+from wazo_provd.config import _DEFAULT_CONFIG
+
+HOST = 'localhost'
+TIMEOUT = 60
+INTERVAL = 1
+
+
+def iterations(timeout, interval):
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        yield
+        time_left = end_time - time.time()
+        delay = time_left % interval
+        time.sleep(delay)
+
+
+def tcp_port_is_open(host, port):
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(INTERVAL)
+        return sock.connect_ex((host, port)) == 0
+
+
+def get_wazo_provd_port():
+    file_config = read_config_file_hierarchy(_DEFAULT_CONFIG)
+    config = ChainMap(file_config, _DEFAULT_CONFIG)
+
+    return config['rest_api']['port']
+
+
+def main():
+    port = get_wazo_provd_port()
+
+    for _ in iterations(TIMEOUT, INTERVAL):
+        if tcp_port_is_open(HOST, port):
+            exit(0)
+    else:
+        print(f'Could not connect to wazo-provd on {HOST}:{port}', file=sys.stderr)
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- **Add wazo-provd-wait to block startup until REST API is ready**
- **Bound the restart loop with a start limit**
- **Remove leftover monit ordering dependency**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Service startup ordering and restart policy only; no auth or provisioning logic changes.
> 
> **Overview**
> **wazo-provd** no longer reports “active” until its REST API accepts TCP connections. A new **`wazo-provd-wait`** helper (installed via `setup.py`) reads `rest_api.port` from the same config hierarchy as the daemon and polls **localhost** for up to **60s**; **`debian/wazo-provd.service`** runs it as **`ExecStartPost`** after twistd starts.
> 
> The unit also adds **`StartLimitBurst=15`** / **`StartLimitIntervalSec=150`** to cap rapid restart loops, and drops the obsolete **`Before=monit.service`** ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ab2c6caa4f4771480c4a203d4d9db5d1032d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->