### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 23.17
 
 * The following configurations have been removed in favor of

--- a/etc/wazo-provd/config.yml
+++ b/etc/wazo-provd/config.yml
@@ -17,8 +17,7 @@ rest_api:
   port: 8666
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 amid:
   host: localhost

--- a/integration_tests/assets/etc/wazo-provd/config.yml
+++ b/integration_tests/assets/etc/wazo-provd/config.yml
@@ -6,5 +6,7 @@ rest_api:
   ip: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null
 bus:
     host: rabbitmq

--- a/wazo_provd/config.py
+++ b/wazo_provd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2010-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """Provisioning server configuration module.
@@ -70,7 +70,7 @@ from __future__ import annotations
 import json
 import logging
 import os.path
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, NotRequired, TypedDict, cast
 from urllib.parse import urlparse
 
 from twisted.python import usage
@@ -127,7 +127,7 @@ class RestApiConfigDict(TypedDict):
 class AuthConfigDict(TypedDict):
     host: str
     port: int
-    prefix: str | None
+    prefix: NotRequired[str | None]
     https: bool
     key_file: str
 
@@ -208,8 +208,7 @@ _DEFAULT_CONFIG: ProvdConfigDict = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-provd-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all internal auth/token traffic is reached at runtime and depends on nginx/wazo-auth routing being deployed first; mis-timed rollout breaks authentication.
> 
> **Overview**
> **Internal wazo-auth** calls from wazo-provd now default to **`localhost:80`** (nginx) instead of the wazo-auth service port **9497**. The shipped `etc/wazo-provd/config.yml` and Python `_DEFAULT_CONFIG` in `config.py` are both updated so layered config stays consistent.
> 
> The default **`auth.prefix`** override is removed from code defaults; **`wazo-auth-client`** already uses `/api/auth`. `AuthConfigDict` marks `prefix` as optional via `NotRequired`.
> 
> **Integration tests** explicitly set `port: 9497` and `prefix: null` because their Docker stacks have no nginx and previously relied on the old defaults.
> 
> **CHANGELOG** documents the 26.09 behavior for operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e99ec6a40a28a28fa781c107fca8b08abbbca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->